### PR TITLE
Check for DESTDIR variable in install script

### DIFF
--- a/Install
+++ b/Install
@@ -4,7 +4,9 @@ ROOT_UID=0
 DEST_DIR=
 
 # Destination directory
-if [ "$UID" -eq "$ROOT_UID" ]; then
+if [ -n ${DESTDIR} ]; then
+  DEST_DIR="${DESTDIR}"
+elif [ "$UID" -eq "$ROOT_UID" ]; then
   DEST_DIR="/usr/share/themes"
 else
   DEST_DIR="$HOME/.themes"


### PR DESCRIPTION
In case someone (distribution packager) wants to set the path himself
lets check for the DESTDIR variable. If none is set do the same as
before and install depending on UID.